### PR TITLE
Fix inconsistency in help dialog text

### DIFF
--- a/data/ui/HelpDialog.ui
+++ b/data/ui/HelpDialog.ui
@@ -114,7 +114,7 @@
                     </style>
                     <child>
                       <object class="AdwActionRow">
-                        <property name="title" translatable="true">Read (Symbolic: r, Numeric: 4)</property>
+                        <property name="title" translatable="true">Read (Symbolically: r, Numerically: 4)</property>
                         <property name="subtitle" translatable="true">Allows viewing the file's contents or listing a directory's contents</property>
                         <child type="prefix">
                           <object class="GtkImage">
@@ -125,7 +125,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow">
-                        <property name="title" translatable="true">Write (Symbolically: 2, Numerically: 2)</property>
+                        <property name="title" translatable="true">Write (Symbolically: w, Numerically: 2)</property>
                         <property name="subtitle" translatable="true">Allows modifying the file's contents or creating/deleting files within a directory</property>
                         <child type="prefix">
                           <object class="GtkImage">

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -2,4 +2,5 @@ ar
 cs
 it
 nl
+pt_BR
 ru

--- a/po/ar.po
+++ b/po/ar.po
@@ -114,7 +114,7 @@ msgid "The types of permissions are:"
 msgstr "أنواع الصلاحيات هي:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "قراءة (رقمي: 4، رمزي r)"
 
 #: data/ui/HelpDialog.ui:118
@@ -122,7 +122,7 @@ msgid "Allows viewing the file's contents or listing a directory's contents"
 msgstr "يسمح بعرض محتويات الملف أو سرد محتويات المجلد"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
 msgstr "كتابة (رقمي: 2، رمزي: w)"
 
 #: data/ui/HelpDialog.ui:129

--- a/po/cs.po
+++ b/po/cs.po
@@ -108,7 +108,7 @@ msgid "The types of permissions are:"
 msgstr "Druhy oprávnění jsou:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "Číst (Symbolický: r, číselný: 4"
 
 #: data/ui/HelpDialog.ui:118
@@ -116,8 +116,8 @@ msgid "Allows viewing the file's contents or listing a directory's contents"
 msgstr "Umožňuje zobrazení obsahu souboru nebo zobrazení obsahu adresáře"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
-msgstr "Zapisovat (Symbolicky: 2, Číselně: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
+msgstr "Zapisovat (Symbolicky: w, Číselně: 2)"
 
 #: data/ui/HelpDialog.ui:129
 msgid "Allows modifying the file's contents or creating/deleting files within a directory"

--- a/po/io.github.ronniedroid.concessio.pot
+++ b/po/io.github.ronniedroid.concessio.pot
@@ -107,7 +107,7 @@ msgid "The types of permissions are:"
 msgstr ""
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr ""
 
 #: data/ui/HelpDialog.ui:118
@@ -115,7 +115,7 @@ msgid "Allows viewing the file's contents or listing a directory's contents"
 msgstr ""
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
 msgstr ""
 
 #: data/ui/HelpDialog.ui:129

--- a/po/it.po
+++ b/po/it.po
@@ -115,7 +115,7 @@ msgid "The types of permissions are:"
 msgstr "I tipi di permessi sono:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "Lettura (Simbolico: r, Numerico: 4)"
 
 #: data/ui/HelpDialog.ui:118
@@ -125,8 +125,8 @@ msgstr ""
 "directory"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
-msgstr "Scrittura (Simbolico: 2, Numericamente: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
+msgstr "Scrittura (Simbolico: w, Numericamente: 2)"
 
 #: data/ui/HelpDialog.ui:129
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -117,7 +117,7 @@ msgid "The types of permissions are:"
 msgstr "De soorten rechten zijn:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "Lezen (symbolisch: r - numeriek: 4)"
 
 #: data/ui/HelpDialog.ui:118
@@ -125,8 +125,8 @@ msgid "Allows viewing the file's contents or listing a directory's contents"
 msgstr "Staat toe dat bestands- of mapinhoud mag worden bekeken"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
-msgstr "Schrijven (symbolisch: 2 - numeriek: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
+msgstr "Schrijven (symbolisch: w - numeriek: 2)"
 
 #: data/ui/HelpDialog.ui:129
 msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# BRAZILIAN PORTUGUESE TRANSLATION.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the io.github.ronniedroid.concessio package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-17 15:39+0300\n"
 "PO-Revision-Date: 2024-11-21 23:25-0300\n"
-"Last-Translator: \n"
+"Last-Translator: Ioseph Silva\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -64,7 +64,7 @@ msgid ""
 "directories and has no effect on files."
 msgstr ""
 "Permite que somente o proprietário do arquivo ou do diretório exclua "
-"arquivos no diretório, mesmo que outras pessoas tenham permissões de "
+"arquivos no diretório, mesmo que outros usuários tenham permissões de "
 "escrita. Aplica-se somente a diretórios e não tem efeito sobre arquivos."
 
 #: data/ui/Form.ui:16
@@ -180,7 +180,7 @@ msgid ""
 "The read, write and execute permissions for the user, here we have 'rwx', "
 "which translated to 4+2+1 and adds to 7"
 msgstr ""
-"As permissões de leitura, escrita e execução para o usuário, aqui temos "
+"São as permissões de leitura, escrita e execução para o usuário, aqui temos "
 "'rwx', que se traduz em 4+2+1, totalizando 7"
 
 #: data/ui/HelpDialog.ui:196
@@ -192,7 +192,7 @@ msgid ""
 "The read, write and execute permissions for the group, here we have 'r-x', "
 "which translated to 4+0+1 and adds to 5"
 msgstr ""
-"As permissões de leitura, escrita e execução para o grupo, aqui temos 'r-x', "
+"São as permissões de leitura, escrita e execução para o grupo, aqui temos 'r-x', "
 "que se traduz em 4+0+1, totalizando 5"
 
 #: data/ui/HelpDialog.ui:202
@@ -204,7 +204,7 @@ msgid ""
 "The read, write and execute permissions for other users, here we have 'r--', "
 "which translated to 4+0+0 and adds to 4"
 msgstr ""
-"As permissões de leitura, escrita e execução para outros usuários, aqui "
+"São as permissões de leitura, escrita e execução para outros usuários, aqui "
 "temos 'r--', que se traduz em 4+0+0, totalizando 4"
 
 #: data/ui/HelpDialog.ui:211
@@ -377,7 +377,7 @@ msgstr "Mostra a janela de ajuda"
 
 #: data/ui/ShortcutsWindow.ui:43
 msgid "Display this keyboard shortcuts window"
-msgstr "Mostra essa janela de atalhos do teclado"
+msgstr "Mostra essa janela"
 
 #: data/io.github.ronniedroid.concessio.desktop:9
 msgid "Permissions;Convertor;Calculator;"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -116,7 +116,7 @@ msgid "The types of permissions are:"
 msgstr "Os tipos de permissões são:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "Leitura (Simbolicamente: r, Numericamente: 4)"
 
 #: data/ui/HelpDialog.ui:118
@@ -125,7 +125,7 @@ msgstr ""
 "Permite visualizar o conteúdo do arquivo ou listar o conteúdo de um diretório"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
 msgstr "Escrita (Simbolicamente: w, Numericamente: 2)"
 
 #: data/ui/HelpDialog.ui:129

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,440 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the io.github.ronniedroid.concessio package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: io.github.ronniedroid.concessio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-17 15:39+0300\n"
+"PO-Revision-Date: 2024-11-21 23:25-0300\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.5\n"
+
+#: data/ui/BoxedList.ui:12 data/ui/HelpDialog.ui:67
+msgid "User"
+msgstr "Usuário"
+
+#: data/ui/BoxedList.ui:21 data/ui/BoxedList.ui:89 data/ui/BoxedList.ui:157
+msgid "Read"
+msgstr "Leitura"
+
+#: data/ui/BoxedList.ui:36 data/ui/BoxedList.ui:104 data/ui/BoxedList.ui:172
+msgid "Write"
+msgstr "Escrita"
+
+#: data/ui/BoxedList.ui:51 data/ui/BoxedList.ui:119 data/ui/BoxedList.ui:187
+msgid "Execute"
+msgstr "Execução"
+
+#: data/ui/BoxedList.ui:80 data/ui/HelpDialog.ui:78
+msgid "Group"
+msgstr "Grupo"
+
+#: data/ui/BoxedList.ui:148 data/ui/HelpDialog.ui:89
+msgid "Others"
+msgstr "Outros"
+
+#: data/ui/BoxedList.ui:247 data/ui/HelpDialog.ui:261
+msgid ""
+"Executes the file with the permissions of the file owner, not the user "
+"running it."
+msgstr ""
+"Executa o arquivo com as permissões do proprietário do arquivo, não do "
+"usuário que está executando."
+
+#: data/ui/BoxedList.ui:288 data/ui/HelpDialog.ui:267
+msgid ""
+"Executes the file with the permissions of the file's group, or ensures new "
+"files in a directory inherit the group."
+msgstr ""
+"Executa o arquivo com as permissões do grupo do arquivo ou garante que os "
+"novos arquivos em um diretório herdem o grupo."
+
+#: data/ui/BoxedList.ui:329 data/ui/HelpDialog.ui:273
+msgid ""
+"Allows only the file owner or directory owner to delete files in the "
+"directory, even if others have write permissions. Only applies to "
+"directories and has no effect on files."
+msgstr ""
+"Permite que somente o proprietário do arquivo ou do diretório exclua "
+"arquivos no diretório, mesmo que outras pessoas tenham permissões de "
+"escrita. Aplica-se somente a diretórios e não tem efeito sobre arquivos."
+
+#: data/ui/Form.ui:16
+msgid "Numeric"
+msgstr "Numérica"
+
+#: data/ui/Form.ui:25 data/ui/Form.ui:49
+msgid "Copy value"
+msgstr "Copiar"
+
+#: data/ui/Form.ui:40
+msgid "Symbolic"
+msgstr "Simbólica"
+
+#: data/ui/HelpDialog.ui:13 data/ui/Window.ui:140
+msgid "Help"
+msgstr "Ajuda"
+
+#: data/ui/HelpDialog.ui:37
+msgid "Unix Permissions"
+msgstr "Permissões Unix"
+
+#: data/ui/HelpDialog.ui:46
+msgid ""
+"The Unix permissions system is used to grant granulated access to file and "
+"directories on a Unix-like operating system"
+msgstr ""
+"O sistema de permissões do Unix é utilizado para conceder acesso granular a "
+"arquivos e diretórios em um sistema operacional do tipo Unix"
+
+#: data/ui/HelpDialog.ui:52
+msgid "Permissions are granted to three groups:"
+msgstr "As permissões são concedidas a três grupos:"
+
+#: data/ui/HelpDialog.ui:68
+msgid "The owner of the file"
+msgstr "O proprietário do arquivo"
+
+#: data/ui/HelpDialog.ui:79
+msgid "A group of users who share access to the file"
+msgstr "Um grupo de usuários que compartilham o acesso ao arquivo"
+
+#: data/ui/HelpDialog.ui:90
+msgid "All other users on the system"
+msgstr "Todos os outros usuários do sistema"
+
+#: data/ui/HelpDialog.ui:102
+msgid "The types of permissions are:"
+msgstr "Os tipos de permissões são:"
+
+#: data/ui/HelpDialog.ui:117
+msgid "Read (Symbolic: r, Numeric: 4)"
+msgstr "Leitura (Simbolicamente: r, Numericamente: 4)"
+
+#: data/ui/HelpDialog.ui:118
+msgid "Allows viewing the file's contents or listing a directory's contents"
+msgstr ""
+"Permite visualizar o conteúdo do arquivo ou listar o conteúdo de um diretório"
+
+#: data/ui/HelpDialog.ui:128
+msgid "Write (Symbolically: 2, Numerically: 2)"
+msgstr "Escrita (Simbolicamente: w, Numericamente: 2)"
+
+#: data/ui/HelpDialog.ui:129
+msgid ""
+"Allows modifying the file's contents or creating/deleting files within a "
+"directory"
+msgstr ""
+"Permite modificar o conteúdo do arquivo ou criar/excluir arquivos dentro de "
+"um diretório"
+
+#: data/ui/HelpDialog.ui:139
+msgid "Execute (Symbolically: x, Numerically: 1)"
+msgstr "Execução (Simbolicamente: x, Numericamente: 1)"
+
+#: data/ui/HelpDialog.ui:140
+msgid "Allows running the file as a program"
+msgstr "Permite executar o arquivo como um programa"
+
+#: data/ui/HelpDialog.ui:153
+msgid ""
+"Permissions can either be represented symbolically or numerically. Symbolic "
+"permissions are represented as a string of ten characters, and numeric is "
+"represented by three numbers (octal notation) for Example:"
+msgstr ""
+"As permissões podem ser representadas de forma simbólica ou numérica. De "
+"forma simbólica, as permissões são representadas por uma sequência de dez "
+"caracteres, enquanto na forma numérica, são representadas por três números "
+"(notação octal). Por exemplo:"
+
+#: data/ui/HelpDialog.ui:159
+msgid "Symbolic: -rwxr-xr--"
+msgstr "Simbólica: -rwxr-xr--"
+
+#: data/ui/HelpDialog.ui:169
+msgid "Numeric: 754"
+msgstr "Numérica: 754"
+
+#: data/ui/HelpDialog.ui:184
+msgid "First character, the file type"
+msgstr "Primeiro caractere, o tipo de arquivo"
+
+#: data/ui/HelpDialog.ui:185
+msgid "can either be '-' for file or 'd' for directory"
+msgstr "pode ser '-' para arquivo ou 'd' para diretório"
+
+#: data/ui/HelpDialog.ui:190
+msgid "First three positions (after file type)"
+msgstr "Primeiras três posições (após o tipo de arquivo)"
+
+#: data/ui/HelpDialog.ui:191
+msgid ""
+"The read, write and execute permissions for the user, here we have 'rwx', "
+"which translated to 4+2+1 and adds to 7"
+msgstr ""
+"As permissões de leitura, escrita e execução para o usuário, aqui temos "
+"'rwx', que se traduz em 4+2+1, totalizando 7"
+
+#: data/ui/HelpDialog.ui:196
+msgid "Second three positions"
+msgstr "Três posições seguintes"
+
+#: data/ui/HelpDialog.ui:197
+msgid ""
+"The read, write and execute permissions for the group, here we have 'r-x', "
+"which translated to 4+0+1 and adds to 5"
+msgstr ""
+"As permissões de leitura, escrita e execução para o grupo, aqui temos 'r-x', "
+"que se traduz em 4+0+1, totalizando 5"
+
+#: data/ui/HelpDialog.ui:202
+msgid "Last three positions"
+msgstr "Últimas três posições"
+
+#: data/ui/HelpDialog.ui:203
+msgid ""
+"The read, write and execute permissions for other users, here we have 'r--', "
+"which translated to 4+0+0 and adds to 4"
+msgstr ""
+"As permissões de leitura, escrita e execução para outros usuários, aqui "
+"temos 'r--', que se traduz em 4+0+0, totalizando 4"
+
+#: data/ui/HelpDialog.ui:211
+msgid "Example command"
+msgstr "Comando de exemplo"
+
+#: data/ui/HelpDialog.ui:220
+msgid "chmod 754 (file name)"
+msgstr "chmod 754 (nome do arquivo)"
+
+#: data/ui/HelpDialog.ui:230
+msgid "Special Permissions"
+msgstr "Permissões Especiais"
+
+#: data/ui/HelpDialog.ui:239
+msgid ""
+"Special permissions make up a fourth access level in addition to user, "
+"group, and other, they allow for additional privileges over the standard "
+"permission sets"
+msgstr ""
+"As permissões especiais formam um quarto nível de acesso, além dos níveis de "
+"usuário, grupo e outros, e oferecem privilégios adicionais em relação às "
+"permissões padrão"
+
+#: data/ui/HelpDialog.ui:245
+msgid "The three special permissions are:"
+msgstr "As três permissões especiais são:"
+
+#: data/ui/HelpDialog.ui:281
+msgid "Special permissions can be represented symbolically or numerically."
+msgstr ""
+"As permissões especiais podem ser representadas de forma simbólica ou "
+"numérica."
+
+#: data/ui/HelpDialog.ui:288
+msgid "Numeric representation:"
+msgstr "Representação numérica:"
+
+#: data/ui/HelpDialog.ui:298
+msgid ""
+"They are denoted as an extra digit before the user, group and others "
+"permissions. Can Either be 0, 4, 2, 1 or any combination of them."
+msgstr ""
+"Elas são indicadas por um dígito extra antes das permissões de usuário, "
+"grupo e outros. Esse dígito pode ser 0, 4, 2, 1 ou qualquer combinação "
+"desses valores."
+
+#: data/ui/HelpDialog.ui:308
+msgid "Symbolical representation:"
+msgstr "Representação simbólica:"
+
+#: data/ui/HelpDialog.ui:324
+msgid "Goes where 'x' normally is for the user"
+msgstr "Fica no lugar do 'x' das permissões do usuário"
+
+#: data/ui/HelpDialog.ui:330
+msgid "Goes where 'x' normally is for the group"
+msgstr "Fica no lugar do 'x' das permissões do grupo"
+
+#: data/ui/HelpDialog.ui:336
+msgid "Goes where 'x' normally is for others"
+msgstr "Fica no lugar do 'x' das permissões de outros"
+
+#: data/ui/HelpDialog.ui:344
+msgid "Symbolic: -rwsr-Sr-t"
+msgstr "Simbólica: -rwsr-Sr-t"
+
+#: data/ui/HelpDialog.ui:354
+msgid "Numeric: 7745"
+msgstr "Númerica: 7745"
+
+#: data/ui/HelpDialog.ui:370
+msgid ""
+"Represented as '4' numerically. Symbolically, it is either 's' if the owner "
+"has execute permissions or 'S' if not."
+msgstr ""
+"Representado numericamente como '4'. Simbolicamente, pode ser 's' se o "
+"proprietário tiver permissões de execução ou 'S' se não tiver."
+
+#: data/ui/HelpDialog.ui:376
+msgid ""
+"Represented as '2' numerically. Symbolically, it is either 's' if the group "
+"has execute permissions or 'S' if not."
+msgstr ""
+"Representado numericamente como '2'. Simbolicamente, pode ser 's' se o "
+"proprietário tiver permissões de execução ou 'S' se não tiver."
+
+#: data/ui/HelpDialog.ui:382
+msgid ""
+"Represented as '1' numerically. Symbolically, it is either 't' if the others "
+"have execute permissions or 'T' if not."
+msgstr ""
+"Representado numericamente como '1'. Simbolicamente, pode ser 't' se o "
+"proprietário tiver permissões de execução ou 'T' se não tiver."
+
+#: data/ui/HelpDialog.ui:390
+msgid "Example commands"
+msgstr "Comandos de exemplo"
+
+#: data/ui/HelpDialog.ui:399
+msgid "chmod 7745 (file name)"
+msgstr "chmod 7745 (nome do arquivo)"
+
+#: data/ui/HelpDialog.ui:409
+msgid "Further reading"
+msgstr "Leitura recomendada"
+
+#: data/ui/Window.ui:4 data/ui/Window.ui:44
+#: data/io.github.ronniedroid.concessio.desktop:3
+#: data/io.github.ronniedroid.concessio.metainfo.xml:5 src/application.js:70
+msgid "Concessio"
+msgstr "Concessio"
+
+#: data/ui/Window.ui:52 data/io.github.ronniedroid.concessio.desktop:4
+#: data/io.github.ronniedroid.concessio.metainfo.xml:6
+msgid "Understand file permissions"
+msgstr "Entenda as permissões de arquivo"
+
+#: data/ui/Window.ui:57
+msgid "Get started"
+msgstr "Começar"
+
+#: data/ui/Window.ui:87
+msgid "Open"
+msgstr "Abrir"
+
+#: data/ui/Window.ui:96
+msgid "Main Menu"
+msgstr "Menu"
+
+#: data/ui/Window.ui:144 data/ui/ShortcutsWindow.ui:42
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos de Teclado"
+
+#: data/ui/Window.ui:148
+msgid "About"
+msgstr "Sobre"
+
+#: data/ui/ShortcutsWindow.ui:8
+msgid "File"
+msgstr "Arquivo"
+
+#: data/ui/ShortcutsWindow.ui:11
+msgid "Open File"
+msgstr "Abrir Arquivo"
+
+#: data/ui/ShortcutsWindow.ui:12
+msgid "Open file chooser dialog"
+msgstr "Abre diálogo de seleção de arquivo"
+
+#: data/ui/ShortcutsWindow.ui:20
+msgid "General"
+msgstr "Geral"
+
+#: data/ui/ShortcutsWindow.ui:23
+msgid "Quit App"
+msgstr "Sair do Aplicativo"
+
+#: data/ui/ShortcutsWindow.ui:29
+msgid "Close Window"
+msgstr "Fechar Janela"
+
+#: data/ui/ShortcutsWindow.ui:35
+msgid "Help dialog"
+msgstr "Ajuda"
+
+#: data/ui/ShortcutsWindow.ui:36
+msgid "Display the help dialog"
+msgstr "Mostra a janela de ajuda"
+
+#: data/ui/ShortcutsWindow.ui:43
+msgid "Display this keyboard shortcuts window"
+msgstr "Mostra essa janela de atalhos do teclado"
+
+#: data/io.github.ronniedroid.concessio.desktop:9
+msgid "Permissions;Convertor;Calculator;"
+msgstr "Permissões;Conversor;Calculadora;"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:11 src/application.js:74
+msgid ""
+"Concessio helps you understand and convert between unix permissions "
+"representations"
+msgstr ""
+"O Concessio ajuda você a entender e converter entre as representações de "
+"permissões do Unix"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:13
+msgid ""
+"Convert between symbolic and numeric representations of UNIX file permissions"
+msgstr ""
+"Converta entre a representação simbólica e a representação numérica das "
+"permissões de arquivos do Unix"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:14
+msgid "Use toggle buttons to update the symbolic and numeric fields"
+msgstr "Use botões para alternar facilmente entre as permissões"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:15
+msgid "Open a file to read it's permissions and convert them"
+msgstr "Abra um arquivo para ler suas permissões e convertê-las"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:16
+msgid "Open the help dialog to read and understand the UNIX permissions system"
+msgstr ""
+"Abra o diálogo de ajuda para ler e entender o sistema de permissões do Unix"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:30
+msgid ""
+"Application main page converting between numeric and symbolic permission"
+msgstr ""
+"Página principal do aplicativo, convertendo entre permissões numéricas e "
+"simbólicas"
+
+#: data/io.github.ronniedroid.concessio.metainfo.xml:34
+msgid "Application help page, explaining unix permissions"
+msgstr "Página de ajuda do aplicativo, explicando as permissões do Unix"
+
+#. Translators: Replace "translator-credits" with your names, one name per line
+#: src/application.js:84
+msgid "translator-credits"
+msgstr "Ioseph Silva"
+
+#: src/application.js:87
+msgid "Special thanks to"
+msgstr "Agradecimentos especiais a"
+
+#: src/window.js:141
+msgid "Copied to clipboard!"
+msgstr "Copiado para a área de transferência!"
+
+#: src/window.js:162
+msgid "Failed to open file."
+msgstr "Falha ao abrir o arquivo."

--- a/po/ru.po
+++ b/po/ru.po
@@ -117,7 +117,7 @@ msgid "The types of permissions are:"
 msgstr "Типы разрешений:"
 
 #: data/ui/HelpDialog.ui:117
-msgid "Read (Symbolic: r, Numeric: 4)"
+msgid "Read (Symbolically: r, Numerically: 4)"
 msgstr "Чтение (Символическое: r, Числовое: 4)"
 
 #: data/ui/HelpDialog.ui:118
@@ -126,7 +126,7 @@ msgstr ""
 "Позволяет просматривать содержимое файла или список содержимого каталога"
 
 #: data/ui/HelpDialog.ui:128
-msgid "Write (Symbolically: 2, Numerically: 2)"
+msgid "Write (Symbolically: w, Numerically: 2)"
 msgstr "Запись (Символическое: w, Числовое: 2)"
 
 #: data/ui/HelpDialog.ui:129


### PR DESCRIPTION
Fixed error in permission type description in the help dialog.

I made a correction to the description, but I couldn't fully verify all translations, so I'm unsure if they are displaying correctly in all languages.

![fix](https://github.com/user-attachments/assets/a4fa31f4-15cf-4c1b-9821-53f7fa7e18b1)